### PR TITLE
fix bug: DropdownLink only working with button

### DIFF
--- a/resources/js/Components/DropdownLink.svelte
+++ b/resources/js/Components/DropdownLink.svelte
@@ -9,6 +9,7 @@
 {#if type !== "button"}
     <Link
         {...$$restProps}
+        {href}
         class="block w-full px-4 py-2 text-left text-sm leading-5 text-gray-700 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 transition duration-150 ease-in-out"
     >
         <slot />

--- a/resources/js/Layouts/Authenticated.svelte
+++ b/resources/js/Layouts/Authenticated.svelte
@@ -80,16 +80,16 @@
                                         </svg>
                                     </button>
                                 </span>
-
-                                <BreezeDropdownLink
-                                    slot="content"
-                                    href="/logout"
-                                    method="post"
-                                    as="button"
-                                    type="button"
-                                >
-                                    Log Out
-                                </BreezeDropdownLink>
+                                <div slot="content">
+                                    <BreezeDropdownLink
+                                        href="/logout"
+                                        method="post"
+                                        as="button"
+                                        type="button"
+                                        >
+                                        Log Out
+                                    </BreezeDropdownLink>
+                                </div>
                             </BreezeDropdown>
                         </div>
                     </div>


### PR DESCRIPTION
Hi,

after adding another Link to the Dropdown Menu in the [Authenticated.svelte](resources/js/Layouts/Authenticated.svelte) component, the menu could not be opened and an error appeared in the console.

I found out that it was simply forgotten to put the `{href}` property on the Link element in the [DropdownLink](resources/js/Components/DropdownLink.svelte) component.

I also wrapped the dropdown link in a div to make the menu more easily extendable. This is unavoidable as soon as one wants to add more than one link.